### PR TITLE
feat: add uos-archive-snipe-keyring.gpg /etc/apt/trusted.gpg.d/

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-keyring (2026.07.01) unstable; urgency=medium
+
+  * add uos-archive-snipe-keyring.gpg /etc/apt/trusted.gpg.d/
+
+ -- lichenggang <lichenggang@deepin.org>  Wed, 01 Jul 2026 15:37:50 +0800
+
 deepin-keyring (2026.02.28) unstable; urgency=medium
 
   * Add uos-archive-snipe-keyring.gpg:

--- a/debian/deepin-keyring.install
+++ b/debian/deepin-keyring.install
@@ -7,3 +7,4 @@ keyrings/deepin-archive-crimson-keyring.gpg /usr/share/keyrings/
 keyrings/deepin-archive-uranus-keyring.gpg /usr/share/keyrings/
 keyrings/deepin-pools-keyring.gpg   /usr/share/keyrings/
 keyrings/uos-archive-snipe-keyring.gpg /usr/share/keyrings/
+keyrings/uos-archive-snipe-keyring.gpg /etc/apt/trusted.gpg.d/


### PR DESCRIPTION
add uos-archive-snipe-keyring.gpg /etc/apt/trusted.gpg.d/

Log: add uos-archive-snipe-keyring.gpg /etc/apt/trusted.gpg.d/

## Summary by Sourcery

Add the uos-archive-snipe keyring to the package so it is installed into /etc/apt/trusted.gpg.d/.